### PR TITLE
Mensagem de erro apresentada na pagina se falhar a busca no twitter

### DIFF
--- a/lib/html.js
+++ b/lib/html.js
@@ -1,5 +1,5 @@
 var html = function(res, data) {
-    var tweets = data.statuses,
+    var tweets = data.statuses || [],
         body = "<html><body><h1>AC/DC: AWS Cloud/DevOps Culture</h1><h2>Twitter results for #acdc</h2><ul style='list-style-type: none;'>%LIST%</ul></body></html>",
         list = [];
 


### PR DESCRIPTION
Se a busca no twitter falhar por algum motivo, por exemplo atras de fireway, eh exibido
na pagina a mensagem: Cannot call method 'forEach' of undefined.

Foi corrigido passando uma lista vazia no lugar da busca, assim a pagina
eh exibida sem erro e com uma lista em branco.
